### PR TITLE
Fixed memory leaks related to closing the simulation window.

### DIFF
--- a/agents_playground/app/main.py
+++ b/agents_playground/app/main.py
@@ -1,9 +1,8 @@
-from typing import Any, Optional
+from typing import Any
 
 from agents_playground.app.playground_app import PlaygroundApp
 from agents_playground.app.options import OptionsProcessor
 from agents_playground.sys.logger import setup_logging
-from agents_playground.sys.profile_tools import timer, size
 
 def main() -> None:
   args: dict[str, Any] = OptionsProcessor().process()

--- a/agents_playground/app/playground_app.py
+++ b/agents_playground/app/playground_app.py
@@ -1,10 +1,8 @@
 from typing import Any, Union
-
 import dearpygui.dearpygui as dpg
 
 from agents_playground.core.observe import Observable, Observer
 from agents_playground.core.simulation import Simulation
-from agents_playground.core.simulation_old import SimulationOld
 from agents_playground.simulation.tag import Tag
 from agents_playground.sys.logger import get_default_logger
 from agents_playground.simulation.sim_events import SimulationEvents
@@ -22,7 +20,7 @@ class PlaygroundApp(Observer):
         'our_town': dpg.generate_uuid()
       }
     }
-    self._active_simulation: Union[SimulationOld, Observable, None] = None
+    self._active_simulation: Union[Simulation, Observable, None] = None
 
   def launch(self) -> None:
     """Run the application"""
@@ -44,7 +42,7 @@ class PlaygroundApp(Observer):
       self._active_simulation = None
 
   @property
-  def active_simulation(self) -> Union[SimulationOld, Observable, None]:
+  def active_simulation(self) -> Union[Simulation, Observable, None]:
     return self._active_simulation
 
   def _enable_windows_context(self) -> None:

--- a/agents_playground/core/sim_loop.py
+++ b/agents_playground/core/sim_loop.py
@@ -11,6 +11,9 @@ from agents_playground.scene.scene import Scene
 from agents_playground.simulation.context import SimulationContext
 from agents_playground.simulation.sim_state import SimulationState
 
+from agents_playground.sys.logger import get_default_logger
+logger = get_default_logger()
+
 class SimLoop:
   """The main loop of a simulation."""
   def __init__(self, scheduler: TaskScheduler = TaskScheduler(), waiter = Waiter()) -> None:
@@ -19,6 +22,9 @@ class SimLoop:
     self._waiter = waiter
     self._sim_current_state: SimulationState = SimulationState.INITIAL
 
+  def __del__(self) -> None:
+    logger.info('SimLoop deleted.')
+
   @property
   def simulation_state(self) -> SimulationState:
     return self._sim_current_state
@@ -26,6 +32,11 @@ class SimLoop:
   @simulation_state.setter
   def simulation_state(self, next_state: SimulationState) -> None:
     self._sim_current_state = next_state
+
+  def end(self) -> None:
+    self._sim_current_state = SimulationState.ENDED
+    if hasattr(self, '_sim_thread'):
+      self._sim_thread.join()
 
   def start(self, context: SimulationContext) -> None:
     """Create a thread for updating the simulation."""

--- a/agents_playground/core/task_scheduler.py
+++ b/agents_playground/core/task_scheduler.py
@@ -5,7 +5,7 @@ from enum import Enum
 import os
 import select
 import time
-from typing import Any, Callable, Deque, Dict, List, Optional, Generator, Union
+from typing import Any, Callable, Deque, Dict, List, Optional, Generator, Union, cast
 from agents_playground.core.counter import Counter
 
 from agents_playground.core.polling_queue import PollingQueue
@@ -97,6 +97,20 @@ class TaskScheduler:
       'sim_stop_time': None,
       'register_memory': [] #  Memory used by self._tasks. Format: Tuple(frame: int, memory_size: float)
     }
+
+  def __del__(self) -> None:
+    logger.info('TaskScheduler is deleted.')
+
+  def purge(self) -> None:
+    """Removes all coroutines from the scheduler."""
+    self._tasks_store.clear()
+    self._ready_to_initialize_queue.clear()
+    self._ready_to_initialize_queue = cast(PollingQueue, None)
+    self._ready_to_resume_queue.clear()
+    self._ready_to_resume_queue = cast(PollingQueue, None)
+    self._hold_for_next_frame.clear()
+    self._registered_tasks_counter.reset()
+    self._pending_tasks.reset()
 
   def metrics(self) -> Dict:
     return self._metrics

--- a/agents_playground/navigation/navigation_mesh.py
+++ b/agents_playground/navigation/navigation_mesh.py
@@ -4,6 +4,8 @@ from typing import Dict, List, ValuesView
 
 from agents_playground.agents.structures import Point
 from agents_playground.simulation.tag import Tag
+from agents_playground.sys.logger import get_default_logger
+logger = get_default_logger()
 
 Junction = SimpleNamespace
 
@@ -11,6 +13,13 @@ class NavigationMesh:
   def __init__(self) -> None:
     self.__junctions: Dict[Tag, Junction] = dict()
     self.__junction_location_index: Dict[Point, Tag] = dict()
+
+  def __del__(self) -> None:
+    logger.info('NavigationMesh is deleted.')
+
+  def purge(self) -> None:
+    self.__junctions.clear()
+    self.__junction_location_index.clear()
 
   def add_junction(self, junction: Junction) -> None:
     if junction.toml_id in self.__junctions:

--- a/agents_playground/navigation/navigator.py
+++ b/agents_playground/navigation/navigator.py
@@ -4,12 +4,13 @@ from pickle import TRUE
 from sre_constants import SUCCESS
 from types import SimpleNamespace
 from typing import List, Optional, Set, Tuple, Union
-from functools import lru_cache
 
 from agents_playground.agents.structures import Point
 from agents_playground.core.priority_queue import PriorityQueue
 from agents_playground.navigation.navigation_mesh import Junction, NavigationMesh
 from agents_playground.navigation.waypoint import Waypoint, NavigationCost
+from agents_playground.sys.logger import get_default_logger
+logger = get_default_logger()
 
 def find_distance(a: Point, b: Point) -> float:
   """Finds the Manhattan distance between two locations."""
@@ -45,6 +46,9 @@ RouteAction = str
 class Navigator:
   def __init__(self) -> None:
     pass
+
+  def __del__(self) -> None:
+    logger.info('Navigator destroyed.')
   
   # TODO: Make this method cache-able
   """
@@ -64,7 +68,6 @@ class Navigator:
   - Need to get more nuanced with how visited_locations is used.
 
   """
-  @lru_cache(maxsize=1156)
   def find_route(
     self, 
     starting_location: Point, 

--- a/agents_playground/scene/scene.py
+++ b/agents_playground/scene/scene.py
@@ -1,7 +1,7 @@
 from argparse import Namespace
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Dict, Iterator, List, Union, ValuesView
+from typing import Any, Dict, Iterator, List, Union, ValuesView, cast
 from agents_playground.agents.structures import Size
 from agents_playground.navigation.navigation_mesh import NavigationMesh
 from agents_playground.simulation.render_layer import RenderLayer
@@ -9,6 +9,8 @@ from agents_playground.simulation.render_layer import RenderLayer
 from agents_playground.simulation.tag import Tag
 from agents_playground.agents.agent import Agent
 from agents_playground.agents.path import InterpolatedPath
+from agents_playground.sys.logger import get_default_logger
+logger = get_default_logger()
 
 EntityGrouping = Dict[Tag, SimpleNamespace]
 
@@ -29,6 +31,21 @@ class Scene:
     self.paths = dict()
     self.__entities = dict()
     self.__layers = dict()
+
+  def __del__(self) -> None:
+    logger.info('Scene is deleted.')
+
+  def purge(self) -> None:
+    self.__cell_size = cast(Size, None)
+    self.__cell_center_x_offset = cast(float, None)
+    self.__cell_center_y_offset = cast(float, None)
+    self.canvas_size = cast(Size, None)
+    self.__entities.clear()
+    self.__layers.clear()
+    self.__nav_mesh.purge()
+    self.agents.clear()
+    self.paths.clear()
+
 
   def add_agent(self, agent: Agent) -> None:
     self.agents[agent.id] = agent

--- a/agents_playground/simulation/context.py
+++ b/agents_playground/simulation/context.py
@@ -1,12 +1,15 @@
 from dataclasses import dataclass
 
-from typing import Any, Callable, Union
+from typing import Any, Callable, Dict, Union, cast
 
 from agents_playground.agents.structures import Size
 from agents_playground.scene.scene import Scene
 from agents_playground.simulation.statistics import SimulationStatistics
 from agents_playground.simulation.tag import Tag
 from agents_playground.styles.agent_style import AgentStyle
+
+from agents_playground.sys.logger import get_default_logger
+logger = get_default_logger()
 
 """
 This is a mess. What am I really trying to do here?
@@ -27,7 +30,7 @@ class SimulationContext:
   # FIXME AgentStyle should probably be on the agent or scene.
   agent_style: AgentStyle
   stats: SimulationStatistics
-  details: dict[Any, Any]
+  details: Dict[Any, Any]
 
   def __init__(self, id_generator: Callable[..., Tag]) -> None:
     self.parent_window = Size()
@@ -35,3 +38,16 @@ class SimulationContext:
     self.agent_style = AgentStyle()
     self.details = dict()
     self.stats = SimulationStatistics(id_generator)
+
+  def __del__(self) -> None:
+    logger.info('SimulationContext is deleted.')
+
+  def purge(self) -> None:
+    self.scene.purge()
+    self.details.clear()
+    self.scene = cast(Scene, None)
+    self.parent_window = cast(Size, None)
+    self.canvas = cast(Size, None)
+    self.agent_style = cast(AgentStyle, None)
+    self.stats = cast(SimulationStatistics, None)
+    self.details = cast(Dict[Any, Any], None)

--- a/tests/core/simulation_test.py
+++ b/tests/core/simulation_test.py
@@ -30,11 +30,24 @@ class TestSimulation:
 
   def test_window_closed_event(self, mocker: MockFixture) -> None:
     mocker.patch('agents_playground.core.observe.Observable.notify')
+    mocker.patch('dearpygui.dearpygui.delete_item')
     fake = FakeSimulation()
+    fake._task_scheduler = mocker.Mock()
+    fake._pre_sim_task_scheduler = mocker.Mock()
+    sim_loop = mocker.Mock()
+    fake._sim_loop = sim_loop
+    fake._context = mocker.Mock()
+
     fake._handle_sim_closed(None, None, None)
-    assert fake.simulation_state is SimulationState.ENDED
+
+    assert sim_loop.simulation_state is SimulationState.ENDED
     fake.notify.assert_called_once()
     fake.notify.assert_called_with(SimulationEvents.WINDOW_CLOSED.value)
+    fake._task_scheduler.stop.assert_called_once()
+    sim_loop.end.assert_called_once()
+    fake._task_scheduler.purge.assert_called_once()
+    fake._pre_sim_task_scheduler.purge.assert_called_once()
+    fake._context.purge.assert_called_once()
 
   def test_starting_and_stopping_the_sim(self, mocker: MockFixture) -> None:
     fake = FakeSimulation()


### PR DESCRIPTION
When I added the lru_cache to the Navigator class I realized that memory wasn't being released the way I expected when a simulation window is closed. I fixed this by adding _purge_ methods to the memory expensive objects and logging when objects are destroyed. 

Now the __handle_sim_closed_ method on the Simulation class ensures that the SimLoop thread is indeed stopped and all container instances (e.g. the TaskScheduler, PollingQueue, dict, etc) are manually cleared.